### PR TITLE
파일 저장, 삭제 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation group: 'com.querydsl', name: 'querydsl-jpa'
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
-
+    implementation 'commons-fileupload:commons-fileupload:1.4'
 
     compileOnly 'org.projectlombok:lombok:1.18.22'
     runtimeOnly 'com.h2database:h2:2.0.206'

--- a/src/main/java/live/munjeong/server/app/config/FileConfiguration.java
+++ b/src/main/java/live/munjeong/server/app/config/FileConfiguration.java
@@ -1,14 +1,17 @@
 package live.munjeong.server.app.config;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
+import org.springframework.web.multipart.support.MultipartFilter;
 
 @Configuration
 public class FileConfiguration {
     @Bean
-    public CommonsMultipartResolver getCommonsMultipartResolver() {
+    public CommonsMultipartResolver commonsMultipartResolver() {
         CommonsMultipartResolver commonsMultipartResolver = new CommonsMultipartResolver();
+        commonsMultipartResolver.setDefaultEncoding("UTF-8");
         commonsMultipartResolver.setMaxUploadSize(1024 * 1024 * 1024); // 1gb
         commonsMultipartResolver.setMaxInMemorySize(1024 * 1024 * 1024);
         return commonsMultipartResolver;

--- a/src/main/java/live/munjeong/server/app/file/DeleteFile.java
+++ b/src/main/java/live/munjeong/server/app/file/DeleteFile.java
@@ -1,0 +1,10 @@
+package live.munjeong.server.app.file;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DeleteFile {
+    Long id;
+}

--- a/src/main/java/live/munjeong/server/app/file/File.java
+++ b/src/main/java/live/munjeong/server/app/file/File.java
@@ -1,6 +1,7 @@
 package live.munjeong.server.app.file;
 
 import live.munjeong.server.app.entity.BaseEntity;
+import live.munjeong.server.app.util.DirectoryPathUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,8 +9,6 @@ import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 @Setter
@@ -34,8 +33,8 @@ public class File extends BaseEntity {
     private String storageNm;
     /**
      *  저장 파일 위치
-     *  파일 타입 / 년 / 월 / 일 / UUID
-     *  ex ) 2022년 1월 14일 test.jpg -> IMAGE/2022/01/14/uuid
+     *  root(file.dir) / 파일 타입 / 년 / 월 / 일 /
+     *  ex ) 2022년 1월 14일 test.jpg -> root/IMAGE/2022/01/14/
      */
     private String storagePath;
 
@@ -57,7 +56,7 @@ public class File extends BaseEntity {
         this.fileType = FileType.getFileType(extensions);
 
         this.storageNm = UUID.randomUUID().toString();
-        this.storagePath = fileType.toString() + LocalDate.now().format(DateTimeFormatter.ofPattern("/yyyy/MM/dd/"));
+        this.storagePath = DirectoryPathUtil.addTodayDirectoryPath(fileType.toString());
     }
 
     public File(UploadFile upLoadFile) {
@@ -67,6 +66,6 @@ public class File extends BaseEntity {
         this.fileType = FileType.getFileType(extensions);
 
         this.storageNm = UUID.randomUUID().toString();
-        this.storagePath = fileType.toString() + LocalDate.now().format(DateTimeFormatter.ofPattern("/yyyy/MM/dd/"));
+        this.storagePath = DirectoryPathUtil.addTodayDirectoryPath(fileType.toString());
     }
 }

--- a/src/main/java/live/munjeong/server/app/file/FileService.java
+++ b/src/main/java/live/munjeong/server/app/file/FileService.java
@@ -3,17 +3,32 @@ package live.munjeong.server.app.file;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class FileService {
     private final FileRepository fileRepository;
 
-    public Long upload(UploadFile uploadFile) {
+    private final FileStore fileStore;
+
+    public File upload(MultipartFile uploadFile) throws IOException {
         log.debug("uploadFile : " + uploadFile);
-        File file = new File(uploadFile);
-        fileRepository.save(file);
-        return file.getId();
+        File file = fileStore.storeFile(uploadFile);
+        return fileRepository.save(file);
+    }
+
+    public void delete(Long fileId) {
+        log.debug("deleteFile fileId [{}] ", fileId);
+        Optional<File> file = fileRepository.findById(fileId);
+        fileStore.deleteFile(file.orElse(null));
+        fileRepository.deleteById(fileId);
     }
 }
+

--- a/src/main/java/live/munjeong/server/app/file/FileStore.java
+++ b/src/main/java/live/munjeong/server/app/file/FileStore.java
@@ -1,22 +1,30 @@
 package live.munjeong.server.app.file;
 
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-@RequiredArgsConstructor
+import static java.io.File.separator;
+
+@Slf4j
+@PropertySource(value = "classpath:file.properties")
 @Component
 public class FileStore {
-    @Value("${file.dir}")
     private final String fileDir;
 
-    public String getFullPath(File file) {
-        return fileDir + file.getStoragePath() + file.getStorageNm();
+    public FileStore(@Value("${file.dir}") String fileDir) {
+        this.fileDir = fileDir;
     }
 
     public List<File> storeFiles(List<MultipartFile> multipartFiles) throws IOException {
@@ -29,6 +37,12 @@ public class FileStore {
         return storeFileResult;
     }
 
+    /**
+     * 파일을 실제 저장소에 저장하기
+     * @param multipartFile Controller에서 넘어오는 MultipartFile객체
+     * @return 저장 성공 시 File 엔티티를 리턴한다.
+     * @throws IOException transferTo 에러시 IOException
+     */
     public File storeFile(MultipartFile multipartFile) throws IOException {
         if (multipartFile.isEmpty()) {
             return null;
@@ -38,7 +52,37 @@ public class FileStore {
         long size = multipartFile.getSize();
         File file = new File(originNm, size);
 
-        multipartFile.transferTo(new java.io.File(getFullPath(file)));
+        multipartFile.transferTo(getRealFile(file));
         return file;
+    }
+
+    /**
+     * 파일 실제 삭제
+     */
+    public boolean deleteFile(File file) {
+        if(file == null) {
+            log.error("delete file is null!!");
+            return false;
+        }
+        log.debug("deleteFile FileId [{}]", file.getId());
+        java.io.File realFile = getRealFile(file);
+        return realFile.delete();
+    }
+
+
+    /**
+     * 파일의 전체경로를 가져온다.
+     * @return String
+     */
+    public String getFullPath(File file) {
+        if( !StringUtils.hasText(file.getStoragePath())
+                || !StringUtils.hasText(file.getStorageNm())) {
+            throw new NoSuchElementException("파일을 찾을 수 없습니다.");
+        }
+        return fileDir + separator + file.getStoragePath() + file.getStorageNm();
+    }
+
+    public java.io.File getRealFile(File file) {
+        return new java.io.File(getFullPath(file));
     }
 }

--- a/src/main/java/live/munjeong/server/app/util/DirectoryPathUtil.java
+++ b/src/main/java/live/munjeong/server/app/util/DirectoryPathUtil.java
@@ -1,0 +1,67 @@
+package live.munjeong.server.app.util;
+
+
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
+import static java.io.File.*;
+
+public class DirectoryPathUtil {
+    @Getter
+    public enum DirDateType {
+        DATE_POLICY_YYYY_MM_DD("yyyy"+separator+"MM"+separator+"dd"+separator),
+        DATE_POLICY_YYYY_MM("yyyy"+separator+"MM"+separator),
+        DATE_POLICY_YYYY("yyyy"+separator);
+
+        private String pattern;
+
+        DirDateType(String pattern) {
+            this.pattern = pattern;
+        }
+    }
+
+    public static String addTodayDirectoryPath(String path) {
+        return addTodayDirectoryPath(path, DirDateType.DATE_POLICY_YYYY_MM_DD);
+    }
+
+    public static String addTodayDirectoryPath(String path, DirDateType dateType) {
+        String format = LocalDate.now().format(DateTimeFormatter.ofPattern(dateType.getPattern()));
+        return getDirectoryPath(path, format);
+
+    }
+
+    public static String getDirectoryPath(String... path) {
+        StringBuilder sb = new StringBuilder();
+
+        for (String str : path) {
+            if(!StringUtils.hasText(str)) continue;
+
+            sb.append(setLastChatSeparator(str));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 문자열의 마지막 문자에  File.separator 추가
+     * @param str 문자열
+     * @return File.separator 추가한 문자열
+     */
+    private static String setLastChatSeparator(@NotBlank String str) {
+        char lastChar = str.charAt(str.length() - 1);
+
+        if (lastChar == separatorChar) {
+            return str;
+        } else if(lastChar == '/' || lastChar == '\\') {
+            return str.substring(0, str.length() - 1) + separator;
+        } else {
+            return str + separator;
+        }
+    }
+}

--- a/src/test/java/live/munjeong/server/app/file/FileServiceTest.java
+++ b/src/test/java/live/munjeong/server/app/file/FileServiceTest.java
@@ -26,13 +26,7 @@ class FileServiceTest {
     @DisplayName("파일 서비스 upload 테스트")
     void uploadTest() {
         //given
-        UploadFile uploadFile = new UploadFile("test1.jpg", 100L);
-        File returnFile = new File(uploadFile);
-        when(fileRepository.save(any()))
-                .thenReturn(returnFile);
 
-        //when, then
-        fileService.upload(uploadFile);
 
     }
 }

--- a/src/test/java/live/munjeong/server/app/file/FileStoreTest.java
+++ b/src/test/java/live/munjeong/server/app/file/FileStoreTest.java
@@ -1,5 +1,7 @@
 package live.munjeong.server.app.file;
 
+import live.munjeong.server.config.TestConfig;
+import org.apache.commons.io.FilenameUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -8,29 +10,54 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import static java.io.File.separator;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
+@Import({TestConfig.class, FileStore.class})
 class FileStoreTest {
     @Mock
     private MultipartFile multipartFile;
 
-    private FileStore fileStore = new FileStore("E:/munjeong/");
+    private FileStore fileStore = new FileStore("files/");
 
+
+    @Test
+    @DisplayName("파일 경로 가져오기 테스트")
+    void getFullPathTest() {
+        //given
+        File file = new File("test.jpg",100L);
+        String toDayPath = LocalDate.now().format(DateTimeFormatter.ofPattern(separator+"yyyy"+separator+"MM"+separator+"dd"));
+
+        //when
+        String path = fileStore.getFullPath(file);
+
+        //then
+        Assertions.assertThat(path).contains("files", "IMAGE" + toDayPath);
+    }
+    
+    
     @Test
     @DisplayName("파일 저장소 파일 저장 테스트")
     void storeFileTest() throws IOException {
-
+        
         //given
         when(multipartFile.isEmpty()).thenReturn(false);
         when(multipartFile.getOriginalFilename()).thenReturn("test.jpg");
@@ -45,6 +72,36 @@ class FileStoreTest {
         Assertions.assertThat(file.getExtensions()).isEqualTo("jpg");
         Assertions.assertThat(file.getSize()).isEqualTo(1000L);
         Assertions.assertThat(file.getFileType()).isEqualTo(FileType.IMAGE);
-        Assertions.assertThat(file.getStoragePath()).isEqualTo(FileType.IMAGE + LocalDate.now().format(DateTimeFormatter.ofPattern("/yyyy/MM/dd/")));
+        Assertions.assertThat(file.getStoragePath()).isEqualTo(FileType.IMAGE + LocalDate.now().format(DateTimeFormatter.ofPattern(separator + "yyyy"+separator+"MM"+separator+"dd"+separator)));
     }
+
+    @Test
+    @DisplayName("파일 삭제 테스트")
+    void deleteTest() throws IOException {
+        //given
+        File file = new File("test.txt", 10L);
+        java.io.File realFile = createTestFile(file);
+        MockMultipartFile mockMultipartFile = getMockMultipartFile(realFile);
+
+        fileStore.deleteFile(file);
+
+    }
+
+    private java.io.File createTestFile(File file) throws IOException {
+        java.io.File testFile = fileStore.getRealFile(file);
+        Path path = testFile.getParentFile().toPath();
+        Files.createDirectories(path);
+        FileWriter fw = new FileWriter(testFile);
+        fw.write("test");
+        fw.flush();
+        fw.close();
+
+        return testFile;
+    }
+
+    private MockMultipartFile getMockMultipartFile(java.io.File file) throws IOException {
+        FileInputStream fileInputStream = new FileInputStream(file);
+        return new MockMultipartFile(file.getName(), fileInputStream);
+    }
+
 }

--- a/src/test/java/live/munjeong/server/app/util/DirectoryPathUtilTest.java
+++ b/src/test/java/live/munjeong/server/app/util/DirectoryPathUtilTest.java
@@ -1,0 +1,26 @@
+package live.munjeong.server.app.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static java.io.File.separator;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DirectoryPathUtilTest {
+    @Test
+    @DisplayName("getDirectoryPath 메서드 테스트")
+    void getDirectoryPathTest() {
+        //given
+        String path1 = "root/";
+        String path2 = "Image\\";
+        String path3 = "test";
+        String path4 = "last";
+        String directoryPath = DirectoryPathUtil.getDirectoryPath(path1, path2, path3, path4);
+
+        Assertions.assertThat(directoryPath).isEqualTo("root" + separator + "Image" + separator + "test" + separator + "last" + separator);
+    }
+
+}


### PR DESCRIPTION
실제 파일 저장, 삭제 관련 로직은 FileStore에서 하도록 만듬
파일을 DB에 저장, 조회, 등 DB관련 로직은 FileService에서 하도록 수정
+ 설정 변경 commons-fileupload 추가